### PR TITLE
Ajout des paroisses vaudoises

### DIFF
--- a/content/vd/aigle.md
+++ b/content/vd/aigle.md
@@ -1,0 +1,17 @@
+---
+title: Paroisse d'Aigle – Yvorne – Corbeyrier
+name: Aigle
+site: https://aigle.eerv.ch
+territoire:
+    - Aigle
+    - Corbeyrier
+    - Yvorne
+NPA:
+    - 1853
+    - 1856
+    - 1860
+meta:
+    - Fontanney
+    - Versvey
+region: Chablais vaudois
+---

--- a/content/vd/balcon-du-jura.md
+++ b/content/vd/balcon-du-jura.md
@@ -1,0 +1,28 @@
+---
+title: Paroisse du Balcon du Jura
+name: Balcon du Jura
+site: https://balcondujura.eerv.ch
+territoire:
+    - Bullet
+    - Mauborget
+    - Sainte-Croix
+NPA:
+    - 1450
+    - 1452
+    - 1453
+    - 1454
+meta:
+    - Chasseron
+    - Culliairy
+    - L'Auberson
+    - La Chaux
+    - La Sagne
+    - La Sagne (Sainte-Croix)
+    - La Vraconnaz
+    - Le Château-Sainte-Croix
+    - Le Château-de-Sainte-Croix
+    - Les Cluds
+    - Les Rasses
+    - Les Replans
+region: Nord vaudois
+---

--- a/content/vd/ballaigues-lignerolle.md
+++ b/content/vd/ballaigues-lignerolle.md
@@ -1,0 +1,22 @@
+---
+title: Paroisse de Ballaigues - Lignerolle
+name: Ballaigues - Lignerolle
+site: https://ballaigueslignerolle.eerv.ch
+territoire:
+    - Ballaigues
+    - L'Abergement
+    - Les Clées
+    - Lignerolle
+    - Montcherand
+    - Sergey
+NPA:
+    - 1338
+    - 1354
+    - 1355
+    - 1356
+    - 1357
+meta:
+    - La Russille
+    - Le Vailloud
+region: Joux - Orbe
+---

--- a/content/vd/baulmes-rances.md
+++ b/content/vd/baulmes-rances.md
@@ -1,0 +1,18 @@
+---
+title: Paroisse de Baulmes - Rances
+name: Baulmes - Rances
+site: https://baulmesrances.eerv.ch
+territoire:
+    - Baulmes
+    - Rances
+    - Valeyres-sous-Rances
+    - Vuiteboeuf
+NPA:
+    - 1358
+    - 1439
+    - 1445
+    - 1446
+meta:
+    - Peney
+region: Joux - Orbe
+---

--- a/content/vd/begnins-burtigny.md
+++ b/content/vd/begnins-burtigny.md
@@ -1,0 +1,19 @@
+---
+title: Paroisse de Begnins - Burtigny
+name: Begnins - Burtigny
+site: https://begninsburtigny.eerv.ch
+territoire:
+    - Bassins
+    - Begnins
+    - Burtigny
+    - Le Vaud
+    - Longirod
+    - Marchissy
+NPA:
+    - 1261
+    - 1268
+    - 1269
+meta:
+    - Hameau de la Cézille (poste de Begnins)
+region: La Côte
+---

--- a/content/vd/bellevaux-saint-luc.md
+++ b/content/vd/bellevaux-saint-luc.md
@@ -1,0 +1,18 @@
+---
+title: Paroisse de Bellevaux - Saint-Luc
+name: Bellevaux - Saint-Luc
+site: https://bellevauxsaintluc.eerv.ch
+territoire:
+    - Lausanne
+NPA:
+    - 1004
+    - 1018
+meta:
+    - Le Chalet-à-Gobet
+    - Montblesson
+    - Montheron
+    - Vernand-Dessous
+    - Vernand-Dessus
+    - Vers-chez-les-Blanc
+region: Lausanne - Epalinges
+---

--- a/content/vd/belmont-lutry.md
+++ b/content/vd/belmont-lutry.md
@@ -1,0 +1,21 @@
+---
+title: Paroisse de Belmont-Lutry
+name: Belmont - Lutry
+site: https://belmontlutry.eerv.ch
+territoire:
+    - Belmont-sur-Lausanne
+    - Lutry
+NPA:
+    - 1090
+    - 1092
+    - 1095
+meta:
+    - Bossières
+    - Châtelard-Lutry
+    - Corsy
+    - La Conversion
+    - La Croix (Lutry)
+    - Les Echerins
+    - Savuit
+region: Lavaux
+---

--- a/content/vd/blonay-saint-legier.md
+++ b/content/vd/blonay-saint-legier.md
@@ -1,0 +1,21 @@
+---
+title: Paroisse de Blonay - Saint-Légier
+name: Blonay - Saint-Légier
+site: https://blonaysaintlegier.eerv.ch
+territoire:
+    - Blonay
+    - Saint-Légier-La Chiésaz
+NPA:
+    - 1806
+    - 1807
+meta:
+    - Bains-de-l'Alliaz
+    - Clies
+    - Hauteville  (Vevey)
+    - L'Alliaz
+    - La Chiésaz
+    - Lally
+    - Les Chevalleyres
+    - Les Pléiades
+region: Riviera - Pays-d'Enhaut
+---

--- a/content/vd/bussigny-villars-sainte-croix.md
+++ b/content/vd/bussigny-villars-sainte-croix.md
@@ -1,0 +1,12 @@
+---
+title: Paroisse de Bussigny - Villars-Sainte-Croix
+name: Bussigny - Villars-Sainte-Croix
+site: https://bussignyvillarssaintecroix.eerv.ch
+territoire:
+    - Bussigny
+    - Villars-Sainte-Croix
+NPA:
+    - 1029
+    - 1030
+region: Les Chamberonnes
+---

--- a/content/vd/chailly-la-cathedrale.md
+++ b/content/vd/chailly-la-cathedrale.md
@@ -1,0 +1,28 @@
+---
+title: Paroisse de Chailly - La Cathédrale
+name: Chailly - La Cathédrale
+site: https://chaillylacathedrale.eerv.ch
+territoire:
+    - Epalinges
+    - Lausanne
+    - Pully
+NPA:
+    - 1003
+    - 1004
+    - 1005
+    - 1009
+    - 1010
+    - 1011
+    - 1012
+    - 1066
+meta:
+    - Le Chalet-à-Gobet
+    - Les Monts-de-Pully
+    - Montblesson
+    - Montheron
+    - Trois Chasseurs
+    - Vernand-Dessous
+    - Vernand-Dessus
+    - Vers-chez-les-Blanc
+region: Lausanne - Epalinges
+---

--- a/content/vd/chardonne-jongny.md
+++ b/content/vd/chardonne-jongny.md
@@ -1,0 +1,15 @@
+---
+title: Paroisse de Chardonne - Jongny
+name: Chardonne - Jongny
+site: https://chardonnejongny.eerv.ch
+territoire:
+    - Chardonne
+    - Jongny
+NPA:
+    - 1801
+    - 1803
+    - 1805
+meta:
+    - Le Mont-Pèlerin
+region: Riviera - Pays-d'Enhaut
+---

--- a/content/vd/chavannes-epenex.md
+++ b/content/vd/chavannes-epenex.md
@@ -1,0 +1,14 @@
+---
+title: Paroisse de Chavannes - Epenex
+name: Chavannes - Epenex
+site: https://chavannesepenex.eerv.ch
+territoire:
+    - Chavannes-près-Renens
+    - Ecublens VD
+    - Renens VD
+NPA:
+    - 1020
+    - 1022
+    - 1024
+region: Les Chamberonnes
+---

--- a/content/vd/chavornay.md
+++ b/content/vd/chavornay.md
@@ -1,0 +1,20 @@
+---
+title: Paroisse de Chavornay
+name: Chavornay
+site: https://chavornay.eerv.ch
+territoire:
+    - Bavois
+    - Chavornay
+NPA:
+    - 1372
+    - 1373
+    - 1374
+    - 1435
+meta:
+    - Chavornay
+    - Corcelles-sur-Chavornay
+    - Essert-Pittet
+    - Le Coudray
+    - Le Pâquier
+region: Joux - Orbe
+---

--- a/content/vd/cheseaux-romanel.md
+++ b/content/vd/cheseaux-romanel.md
@@ -1,0 +1,24 @@
+---
+title: Paroisse de Cheseaux - Romanel
+name: Cheseaux - Romanel
+site: https://cheseauxromanel.eerv.ch
+territoire:
+    - Cheseaux-sur-Lausanne
+    - Lausanne
+    - Romanel-sur-Lausanne
+NPA:
+    - 1000
+    - 1032
+    - 1033
+meta:
+    - Lausanne 25
+    - Lausanne 26
+    - Lausanne 27
+    - Le Chalet-à-Gobet
+    - Montblesson
+    - Montheron
+    - Vernand-Dessous
+    - Vernand-Dessus
+    - Vers-chez-les-Blanc
+region: Les Chamberonnes
+---

--- a/content/vd/clarens.md
+++ b/content/vd/clarens.md
@@ -1,0 +1,43 @@
+---
+title: Paroisse de Clarens
+name: Clarens
+site: https://clarens.eerv.ch
+territoire:
+    - Montreux
+    - Veytaux
+NPA:
+    - 1815
+    - 1816
+    - 1817
+    - 1820
+meta:
+    - Baugy
+    - Brent
+    - Caux
+    - Chailly-Montreux
+    - Chailly-sur-Clarens
+    - Chamby
+    - Chaulin
+    - Chernex
+    - Chêne
+    - Clarens
+    - Collonge
+    - Cornaux
+    - Crin
+    - Fontanivent
+    - Glion
+    - Les Avants
+    - Les Planches
+    - Mont-Fleuri
+    - Pallens
+    - Pertit
+    - Planchamp
+    - Sonzier
+    - Sâles
+    - Tavel
+    - Territet
+    - Vernex
+    - Villard-sur-Chamby
+    - Vuarennes
+region: Riviera - Pays-d'Enhaut
+---

--- a/content/vd/coeur-de-la-cote.md
+++ b/content/vd/coeur-de-la-cote.md
@@ -1,0 +1,28 @@
+---
+title: Paroisse du Coeur de la Côte
+name: Coeur de la Côte
+site: https://coeurdelacote.eerv.ch
+territoire:
+    - Bursinel
+    - Bursins
+    - Dully
+    - Gilly
+    - Luins
+    - Mont-sur-Rolle
+    - Perroy
+    - Rolle
+    - Tartegnin
+    - Vinzel
+NPA:
+    - 1166
+    - 1180
+    - 1182
+    - 1183
+    - 1184
+    - 1185
+    - 1195
+meta:
+    - Le Vernay
+    - Vincy
+region: La Côte
+---

--- a/content/vd/corsier-corseaux.md
+++ b/content/vd/corsier-corseaux.md
@@ -1,0 +1,15 @@
+---
+title: Paroisse de Corsier - Corseaux
+name: Corsier - Corseaux
+site: https://corsiercorseaux.eerv.ch
+territoire:
+    - Corseaux
+    - Corsier-sur-Vevey
+NPA:
+    - 1802
+    - 1804
+meta:
+    - Fenil-sur-Corsier
+    - Les Monts-de-Corsier
+region: Riviera - Pays-d'Enhaut
+---

--- a/content/vd/cossonay-grancy.md
+++ b/content/vd/cossonay-grancy.md
@@ -1,0 +1,25 @@
+---
+title: Paroisse de Cossonay - Grancy
+name: Cossonay - Grancy
+site: https://cossonaygrancy.eerv.ch
+territoire:
+    - Cossonay
+    - Dizy
+    - Gollion
+    - Grancy
+    - La Chaux (Cossonay)
+    - Lussery-Villars
+    - Senarclens
+NPA:
+    - 1117
+    - 1124
+    - 1304
+    - 1307
+    - 1308
+meta:
+    - Allens
+    - Cossonay-Ville
+    - Lussery
+    - Villars-Lussery
+region: Gros-de-Vaud - Venoge
+---

--- a/content/vd/crissier.md
+++ b/content/vd/crissier.md
@@ -1,0 +1,10 @@
+---
+title: Paroisse de Crissier
+name: Crissier
+site: https://crissier.eerv.ch
+territoire:
+    - Crissier
+NPA:
+    - 1023
+region: Les Chamberonnes
+---

--- a/content/vd/curtilles-lucens.md
+++ b/content/vd/curtilles-lucens.md
@@ -1,0 +1,47 @@
+---
+title: Paroisse de Curtilles - Lucens
+name: Curtilles - Lucens
+site: https://curtilleslucens.eerv.ch
+territoire:
+    - Curtilles
+    - Dompierre VD
+    - Lausanne
+    - Lovatens
+    - Lucens
+    - Prévonloup
+    - Valbroye
+NPA:
+    - 1000
+    - 1521
+    - 1522
+    - 1526
+    - 1682
+    - 1683
+meta:
+    - Brenles
+    - Cerniaz
+    - Cerniaz VD
+    - Chesalles-sur-Moudon
+    - Combremont-le-Grand
+    - Combremont-le-Petit
+    - Cremin
+    - Forel-sur-Lucens
+    - Granges-près-Marnand
+    - Lausanne 25
+    - Lausanne 26
+    - Lausanne 27
+    - Le Chalet-à-Gobet
+    - Lucens
+    - Marnand
+    - Montblesson
+    - Montheron
+    - Oulens-sur-Lucens
+    - Sarzens
+    - Sassel
+    - Seigneux
+    - Vernand-Dessous
+    - Vernand-Dessus
+    - Vers-chez-les-Blanc
+    - Villars-Bramard
+region: La Broye
+---

--- a/content/vd/echallens.md
+++ b/content/vd/echallens.md
@@ -1,0 +1,12 @@
+---
+title: Paroisse d'Echallens
+name: Echallens
+site: https://echallens.eerv.ch
+territoire:
+    - Echallens
+    - Saint-Barthélemy VD
+    - Villars-le-Terroir
+NPA:
+    - 1040
+region: Gros-de-Vaud - Venoge
+---

--- a/content/vd/ecublens-saint-sulpice.md
+++ b/content/vd/ecublens-saint-sulpice.md
@@ -1,0 +1,12 @@
+---
+title: Paroisse d'Ecublens - Saint-Sulpice
+name: Ecublens - Saint-Sulpice
+site: https://ecublenssaintsulpice.eerv.ch
+territoire:
+    - Ecublens VD
+    - Saint-Sulpice VD
+NPA:
+    - 1024
+    - 1025
+region: Les Chamberonnes
+---

--- a/content/vd/genolier.md
+++ b/content/vd/genolier.md
@@ -1,0 +1,16 @@
+---
+title: Paroisse de Genolier
+name: Genolier
+site: https://genolier.eerv.ch
+territoire:
+    - Duillier
+    - Genolier
+    - Givrins
+    - Trélex
+NPA:
+    - 1266
+    - 1270
+    - 1271
+    - 1272
+region: La Côte
+---

--- a/content/vd/gimel-longirod.md
+++ b/content/vd/gimel-longirod.md
@@ -1,0 +1,26 @@
+---
+title: Paroisse de Gimel - Longirod
+name: Gimel - Longirod
+site: https://gimellongirod.eerv.ch
+territoire:
+    - Essertines-sur-Rolle
+    - Gimel
+    - Le Vaud
+    - Longirod
+    - Marchissy
+    - Saint-George
+    - Saint-Oyens
+    - Saubraz
+NPA:
+    - 1186
+    - 1187
+    - 1188
+    - 1189
+    - 1261
+meta:
+    - Bugnaux
+    - Châtel-sur-Rolle
+    - Creux du Mas
+    - Roussillon
+region: Morges - Aubonne
+---

--- a/content/vd/gland.md
+++ b/content/vd/gland.md
@@ -1,0 +1,13 @@
+---
+title: Paroisse de Gland
+name: Gland
+site: https://gland.eerv.ch
+territoire:
+    - Coinsins
+    - Gland
+    - Vich
+NPA:
+    - 1196
+    - 1267
+region: La Côte
+---

--- a/content/vd/grandson.md
+++ b/content/vd/grandson.md
@@ -1,0 +1,21 @@
+---
+title: Paroisse de Grandson
+name: Grandson
+site: https://grandson.eerv.ch
+territoire:
+    - Giez
+    - Grandson
+    - Orges
+NPA:
+    - 1422
+    - 1429
+    - 1430
+meta:
+    - Bru
+    - Corcelettes
+    - La Perraudettaz
+    - La Poissine
+    - Les Tuileries-de-Grandson
+    - Péroset
+region: Nord vaudois
+---

--- a/content/vd/granges-et-environs.md
+++ b/content/vd/granges-et-environs.md
@@ -1,14 +1,15 @@
 ---
 title: Paroisse de Granges et environs
 name: Granges et environs
-site: https://grangesetenvirons.eerv.ch/
+site: https://grangesetenvirons.eerv.ch
 territoire:
     - Champtauroz
-    - Dompierre
+    - Dompierre VD
     - Henniez
+    - Lovatens
     - Prévonloup
     - Trey
-    - Treytorrens
+    - Treytorrens (Payerne)
     - Valbroye
     - Villarzel
 NPA:
@@ -18,24 +19,26 @@ NPA:
     - 1534
     - 1535
     - 1536
-    - 1538
     - 1537
+    - 1538
     - 1552
+    - 1554
     - 1555
     - 1682
 meta:
     - Cerniaz
+    - Cerniaz VD
     - Combremont-le-Grand
     - Combremont-le-Petit
     - Granges-près-Marnand
     - Granges-sous-Trey
-    - Les Granges de Dompierre
     - Marnand
     - Rossens
+    - Rossens VD
     - Sassel
-    - Sédeilles
     - Seigneux
+    - Sédeilles
     - Villars-Bramard
+    - Villarzel
 region: La Broye
 ---
-

--- a/content/vd/haute-menthue.md
+++ b/content/vd/haute-menthue.md
@@ -1,0 +1,25 @@
+---
+title: Paroisse de la Haute-Menthue
+name: Haute-Menthue
+site: https://hautementhue.eerv.ch
+territoire:
+    - Bottens
+    - Jorat-Menthue
+    - Montilliez
+    - Poliez-Pittet
+NPA:
+    - 1041
+    - 1043
+    - 1058
+meta:
+    - Dommartin
+    - Montaubion-Chardonney
+    - Naz
+    - Peney-le-Jorat
+    - Poliez-le-Grand
+    - Sottens
+    - Sugnens
+    - Villars-Mendraz
+    - Villars-Tiercelin
+region: Gros-de-Vaud - Venoge
+---

--- a/content/vd/jorat.md
+++ b/content/vd/jorat.md
@@ -1,0 +1,37 @@
+---
+title: Paroisse du Jorat
+name: Jorat
+site: https://jorat.eerv.ch
+territoire:
+    - Corcelles-le-Jorat
+    - Jorat-Mézières
+    - Montpreveyres
+    - Ropraz
+    - Servion
+    - Vucherens
+    - Vulliens
+NPA:
+    - 1076
+    - 1077
+    - 1080
+    - 1081
+    - 1082
+    - 1083
+    - 1084
+    - 1085
+    - 1088
+    - 1509
+meta:
+    - Bressonnaz-Dessus
+    - Carrouge
+    - Carrouge VD
+    - Ferlens
+    - Ferlens VD
+    - Les Cullayes
+    - Mézières
+    - Mézières VD
+    - Seppey-pres-Vulliens
+    - Servion
+    - Ussières
+region: La Broye
+---

--- a/content/vd/l-arnon.md
+++ b/content/vd/l-arnon.md
@@ -1,0 +1,29 @@
+---
+title: Paroisse de L'Arnon
+name: L'Arnon
+site: https://larnon.eerv.ch
+territoire:
+    - Bonvillars
+    - Champagne
+    - Fiez
+    - Fontaines-sur-Grandson
+    - Grandevent
+    - Novalles
+    - Tévenon
+    - Vugelles-La Mothe
+NPA:
+    - 1420
+    - 1421
+    - 1423
+    - 1424
+    - 1427
+    - 1431
+meta:
+    - Fontanezier
+    - La Mothe
+    - Romairon
+    - Vaugondry
+    - Villars-Burquin
+    - les Vullierens
+region: Nord vaudois
+---

--- a/content/vd/l-aubonne.md
+++ b/content/vd/l-aubonne.md
@@ -1,0 +1,34 @@
+---
+title: Paroisse de L'Aubonne
+name: L'Aubonne
+site: https://laubonne.eerv.ch
+territoire:
+    - Allaman
+    - Aubonne
+    - Bougy-Villars
+    - Buchillon
+    - Etoy
+    - Féchy
+    - Lavigny
+    - Saint-Livres
+NPA:
+    - 1163
+    - 1164
+    - 1165
+    - 1170
+    - 1172
+    - 1173
+    - 1174
+    - 1175
+    - 1176
+meta:
+    - Aubonne
+    - La Martheray
+    - Le Saugey
+    - Les Cassivettes
+    - Montherod
+    - Pizy
+    - Pizy (2011)
+    - Signal-de-Bougy
+region: Morges - Aubonne
+---

--- a/content/vd/l-etincelle.md
+++ b/content/vd/l-etincelle.md
@@ -1,0 +1,6 @@
+---
+title: Communauté de L'Etincelle
+name: L'Etincelle
+site: https://letincelle.eerv.ch
+region: 
+---

--- a/content/vd/la-dole.md
+++ b/content/vd/la-dole.md
@@ -1,9 +1,9 @@
 ---
 title: Paroisse de La Dôle
 name: La Dôle
-site: https://ladole.eerv.ch/
+site: https://ladole.eerv.ch
 territoire:
-    - Arnex/Nyon
+    - Arnex-sur-Nyon
     - Borex
     - Chéserex
     - Crassier
@@ -20,5 +20,12 @@ NPA:
     - 1276
     - 1277
     - 1278
+meta:
+    - Avenex
+    - Bonmont
+    - La Florettaz
+    - Petit-Eysins
+    - Signy
+    - Tranchepied
 region: La Côte
 ---

--- a/content/vd/la-sallaz-les-croisettes.md
+++ b/content/vd/la-sallaz-les-croisettes.md
@@ -1,0 +1,29 @@
+---
+title: Paroisse La Sallaz - Les Croisettes
+name: La Sallaz - Les Croisettes
+site: https://lasallazlescroisettes.eerv.ch
+territoire:
+    - Epalinges
+    - Lausanne
+    - Pully
+NPA:
+    - 1000
+    - 1005
+    - 1009
+    - 1010
+    - 1012
+    - 1066
+meta:
+    - Lausanne 25
+    - Lausanne 26
+    - Lausanne 27
+    - Le Chalet-à-Gobet
+    - Les Monts-de-Pully
+    - Montblesson
+    - Montheron
+    - Trois Chasseurs
+    - Vernand-Dessous
+    - Vernand-Dessus
+    - Vers-chez-les-Blanc
+region: Lausanne - Epalinges
+---

--- a/content/vd/la-sarraz.md
+++ b/content/vd/la-sarraz.md
@@ -1,0 +1,22 @@
+---
+title: Paroisse de La Sarraz
+name: La Sarraz
+site: https://lasarraz.eerv.ch
+territoire:
+    - Chevilly
+    - Eclépens
+    - Ferreyres
+    - La Sarraz
+    - Orny
+    - Pompaples
+NPA:
+    - 1312
+    - 1313
+    - 1315
+    - 1316
+    - 1317
+    - 1318
+meta:
+    - Saint-Loup
+region: Gros-de-Vaud - Venoge
+---

--- a/content/vd/la-tour-de-peilz.md
+++ b/content/vd/la-tour-de-peilz.md
@@ -1,0 +1,12 @@
+---
+title: Paroisse de La Tour-de-Peilz
+name: La Tour-de-Peilz
+site: https://latourdepeilz.eerv.ch
+territoire:
+    - La Tour-de-Peilz
+NPA:
+    - 1814
+meta:
+    - Burier
+region: Riviera - Pays-d'Enhaut
+---

--- a/content/vd/la-vallee.md
+++ b/content/vd/la-vallee.md
@@ -1,0 +1,36 @@
+---
+title: Paroisse de La Vallée
+name: La Vallée
+site: https://lavallee.eerv.ch
+territoire:
+    - L'Abbaye
+    - Le Chenit
+    - Le Lieu
+NPA:
+    - 1341
+    - 1343
+    - 1344
+    - 1345
+    - 1346
+    - 1347
+    - 1348
+meta:
+    - Chez-le-Maître
+    - L'Orient
+    - La Golisse
+    - Le Brassus
+    - Le Campe
+    - Le Lieu
+    - Le Marchairuz
+    - Le Pont
+    - Le Rocheray
+    - Le Sentier
+    - Le Solliat
+    - Le Séchey
+    - Les Bioux
+    - Les Charbonnières
+    - Les Esserts-de-Rive
+    - Piguet-Dessous
+    - Piguet-Dessus
+region: Joux - Orbe
+---

--- a/content/vd/le-haut-talent.md
+++ b/content/vd/le-haut-talent.md
@@ -1,0 +1,42 @@
+---
+title: Paroisse du Haut-Talent
+name: Le Haut-Talent
+site: https://lehauttalent.eerv.ch
+territoire:
+    - Bottens
+    - Bretigny-sur-Morrens
+    - Cugy VD
+    - Froideville
+    - Jorat-Menthue
+    - Lausanne
+    - Montilliez
+    - Morrens VD
+    - Poliez-Pittet
+NPA:
+    - 1000
+    - 1041
+    - 1053
+    - 1054
+    - 1055
+meta:
+    - Dommartin
+    - Hameau de Béthusy
+    - Lausanne 25
+    - Lausanne 26
+    - Lausanne 27
+    - Le Chalet-à-Gobet
+    - Montaubion-Chardonney
+    - Montblesson
+    - Montheron
+    - Naz
+    - Peney-le-Jorat
+    - Poliez-le-Grand
+    - Sottens
+    - Sugnens
+    - Vernand-Dessous
+    - Vernand-Dessus
+    - Vers-chez-les-Blanc
+    - Villars-Mendraz
+    - Villars-Tiercelin
+region: Les Chamberonnes
+---

--- a/content/vd/le-mont-sur-lausanne.md
+++ b/content/vd/le-mont-sur-lausanne.md
@@ -1,0 +1,14 @@
+---
+title: Paroisse du Mont-sur-Lausanne
+name: Le Mont-sur-Lausanne
+site: https://lemontsurlausanne.eerv.ch
+territoire:
+    - Le Mont-sur-Lausanne
+NPA:
+    - 1052
+meta:
+    - Le Grand-Mont
+    - Le Petit-Mont
+    - Les Planches
+region: Les Chamberonnes
+---

--- a/content/vd/les-avancons.md
+++ b/content/vd/les-avancons.md
@@ -1,0 +1,32 @@
+---
+title: Paroisse des Avançons - Bex - Gryon
+name: Les Avançons
+site: https://lesavancons.eerv.ch
+territoire:
+    - Bex
+    - Gryon
+    - Lavey-Morcles
+NPA:
+    - 1880
+    - 1882
+    - 1892
+meta:
+    - Anzeindaz
+    - Chêne-sur-Bex
+    - Fenalet-sur-Bex
+    - Frenières-sur-Bex
+    - La Barboleusaz
+    - Lavey-Village
+    - Lavey-les-Bains
+    - Le Bévieux
+    - Le Châtel
+    - Les Dévens
+    - Les Pars
+    - Les Plans-sur-Bex
+    - Les Posses-sur-Bex
+    - Morcles
+    - Pont-de-Nant
+    - Solalex
+    - Vasselin
+region: Chablais vaudois
+---

--- a/content/vd/lonay-preverenges-vullierens.md
+++ b/content/vd/lonay-preverenges-vullierens.md
@@ -1,0 +1,17 @@
+---
+title: Paroisse de Lonay - Préverenges - Vullierens
+name: Lonay - Préverenges - Vullierens
+site: https://lonaypreverenges.eerv.ch
+territoire:
+    - Bremblens
+    - Denges
+    - Echandens
+    - Lonay
+    - Préverenges
+NPA:
+    - 1026
+    - 1027
+    - 1028
+    - 1121
+region: Morges - Aubonne
+---

--- a/content/vd/monde-du-travail.md
+++ b/content/vd/monde-du-travail.md
@@ -1,0 +1,6 @@
+---
+title: Monde du travail
+name: Monde du Travail
+site: https://mondedutravail.eerv.ch
+region: 
+---

--- a/content/vd/mont-aubert.md
+++ b/content/vd/mont-aubert.md
@@ -1,0 +1,19 @@
+---
+title: Paroisse du Mont-Aubert
+name: Mont-Aubert
+site: https://montaubert.eerv.ch
+territoire:
+    - Concise
+    - Corcelles-près-Concise
+    - Mutrux
+    - Onnens VD
+    - Provence
+NPA:
+    - 1425
+    - 1426
+    - 1428
+meta:
+    - La Raisse
+    - Les Prises * (VD/NE)
+region: Nord vaudois
+---

--- a/content/vd/montagny-champvent.md
+++ b/content/vd/montagny-champvent.md
@@ -1,0 +1,25 @@
+---
+title: Paroisse de Montagny - Champvent
+name: Montagny - Champvent
+site: https://montagnychampvent.eerv.ch
+territoire:
+    - Chamblon
+    - Champvent
+    - Mathod
+    - Montagny-près-Yverdon
+    - Suscévaz
+    - Treycovagnes
+    - Valeyres-sous-Montagny
+NPA:
+    - 1436
+    - 1437
+    - 1438
+    - 1441
+    - 1442
+    - 1443
+meta:
+    - Champvent
+    - Essert-sous-Champvent
+    - Villars-sous-Champvent
+region: Nord vaudois
+---

--- a/content/vd/montreux.md
+++ b/content/vd/montreux.md
@@ -1,0 +1,40 @@
+---
+title: Paroisse de Montreux - Veytaux
+name: Montreux
+site: https://montreux.eerv.ch
+territoire:
+    - Montreux
+    - Veytaux
+NPA:
+    - 1820
+    - 1822
+meta:
+    - Baugy
+    - Brent
+    - Caux
+    - Chailly-sur-Clarens
+    - Chamby
+    - Chaulin
+    - Chernex
+    - Chêne
+    - Clarens
+    - Collonge
+    - Cornaux
+    - Crin
+    - Fontanivent
+    - Glion
+    - Les Avants
+    - Les Planches
+    - Mont-Fleuri
+    - Pallens
+    - Pertit
+    - Planchamp
+    - Sonzier
+    - Sâles
+    - Tavel
+    - Territet
+    - Vernex
+    - Villard-sur-Chamby
+    - Vuarennes
+region: Riviera - Pays-d'Enhaut
+---

--- a/content/vd/morges-echichens.md
+++ b/content/vd/morges-echichens.md
@@ -1,0 +1,18 @@
+---
+title: Paroisse de Morges - Echichens
+name: Morges - Echichens
+site: https://morges.eerv.ch
+territoire:
+    - Echichens
+    - Morges
+NPA:
+    - 1110
+    - 1112
+    - 1125
+meta:
+    - Colombier
+    - Echichens
+    - Monnaz
+    - Saint-Saphorin-sur-Morges
+region: Morges - Aubonne
+---

--- a/content/vd/moudon-syens.md
+++ b/content/vd/moudon-syens.md
@@ -1,9 +1,13 @@
 ---
-title: Paroisse de Moudon-Syens
-name: Moudon-Syens
-site: https://moudonsyens.eerv.ch/
+title: Paroisse de Moudon - Syens
+name: Moudon - Syens
+site: https://moudonsyens.eerv.ch
 territoire:
+    - Bussy-sur-Moudon
+    - Chavannes-sur-Moudon
+    - Hermenches
     - Moudon
+    - Rossenges
     - Syens
 NPA:
     - 1510
@@ -11,13 +15,6 @@ NPA:
     - 1513
     - 1514
 meta:
-    - Bussy-sur-Moudon
     - Bressonnaz
-    - Chavannes-sur-Moudon
-    - Hermenches
-    - Rossenges
-    - cathédrale de la Broye
-    - Saint-Étienne
 region: La Broye
 ---
-

--- a/content/vd/nyon.md
+++ b/content/vd/nyon.md
@@ -1,0 +1,14 @@
+---
+title: Paroisse de Nyon
+name: Nyon
+site: https://nyon.eerv.ch
+territoire:
+    - Crans VD
+    - Nyon
+    - Prangins
+NPA:
+    - 1197
+    - 1260
+    - 1299
+region: La Côte
+---

--- a/content/vd/ollon-villars.md
+++ b/content/vd/ollon-villars.md
@@ -1,0 +1,34 @@
+---
+title: Paroisse réformée d'Ollon - Villars
+name: Ollon - Villars
+site: https://ollonvillars.eerv.ch
+territoire:
+    - Ollon
+NPA:
+    - 1867
+meta:
+    - Antagnes
+    - Arveyes
+    - Auliens
+    - Bretaye
+    - Chesières
+    - Crettaz
+    - Exergillod
+    - Forchex
+    - Glutieres
+    - Huemoz
+    - Les Combes
+    - Les Ecovets
+    - Les Fontaines
+    - Ollon VD
+    - Pallueyres
+    - Panex
+    - Plambuit
+    - Plan d'Essert
+    - Saint-Triphon
+    - Salaz
+    - Verschiez
+    - Villars-sur-Ollon
+    - Villy
+region: Chablais vaudois
+---

--- a/content/vd/orbe-agiez.md
+++ b/content/vd/orbe-agiez.md
@@ -1,0 +1,16 @@
+---
+title: Paroisse d'Orbe - Agiez
+name: Orbe - Agiez
+site: https://orbeagiez.eerv.ch
+territoire:
+    - Agiez
+    - Arnex-sur-Orbe
+    - Bofflens
+    - Orbe
+NPA:
+    - 1321
+    - 1350
+    - 1352
+    - 1353
+region: Joux - Orbe
+---

--- a/content/vd/ormonts-leysin.md
+++ b/content/vd/ormonts-leysin.md
@@ -1,0 +1,33 @@
+---
+title: Paroisse des Ormonts - Leysin
+name: Ormonts - Leysin
+site: https://ormontsleysin.eerv.ch
+territoire:
+    - Leysin
+    - Ormont-Dessous
+    - Ormont-Dessus
+NPA:
+    - 1854
+    - 1862
+    - 1863
+    - 1864
+    - 1865
+    - 1866
+meta:
+    - Cergnat
+    - Crettaz
+    - La Comballaz
+    - La Forclaz
+    - La Forclaz VD
+    - Le Pont-de-la-Tine
+    - Le Rosex
+    - Le Sépey
+    - Les Aviolats
+    - Les Diablerets
+    - Les Mosses
+    - Les Planches
+    - Les Voettes
+    - Vers-l'Eglise
+    - Veyges (hameaux)
+region: Chablais vaudois
+---

--- a/content/vd/oron-palezieux.md
+++ b/content/vd/oron-palezieux.md
@@ -1,0 +1,31 @@
+---
+title: Paroisse d'Oron - Palézieux
+name: Oron - Palézieux
+site: https://oronpalezieux.eerv.ch
+territoire:
+    - Essertes
+    - Maracon
+    - Oron
+NPA:
+    - 1078
+    - 1607
+    - 1608
+    - 1610
+    - 1612
+    - 1613
+meta:
+    - Bussigny-sur-Oron
+    - Chesalles-sur-Oron
+    - Châtillens
+    - Ecoteaux
+    - La Rogivue
+    - Les Tavernes
+    - Les Thioleyres
+    - Oron-la-Ville
+    - Oron-le-Châtel
+    - Palézieux
+    - Palézieux-Village
+    - Serix
+    - Vuibroye
+region: La Broye
+---

--- a/content/vd/paquier-donneloye.md
+++ b/content/vd/paquier-donneloye.md
@@ -1,0 +1,34 @@
+---
+title: Paroisse de Pâquier - Donneloye
+name: Pâquier - Donneloye
+site: https://paquierdonneloye.eerv.ch
+territoire:
+    - Bioley-Magnoux
+    - Chavannes-le-Chêne
+    - Chêne-Pâquier
+    - Donneloye
+    - Démoret
+    - Molondin
+    - Montanaire
+NPA:
+    - 1407
+    - 1408
+    - 1409
+    - 1415
+    - 1464
+meta:
+    - Chanéaz
+    - Chapelle-sur-Moudon
+    - Correvon
+    - Denezy
+    - Donneloye
+    - Gossens
+    - Martherenges
+    - Mézery-près-Donneloye
+    - Neyruz-sur-Moudon
+    - Peyres-Possens
+    - Prahins
+    - Saint-Cierges
+    - Thierrens
+region: Nord vaudois
+---

--- a/content/vd/payerne-corcelles-ressudens.md
+++ b/content/vd/payerne-corcelles-ressudens.md
@@ -1,0 +1,6 @@
+---
+title: Paroisse de Payerne - Corcelles - Ressudens
+name: Payerne - Corcelles - Ressudens
+site: https://payernecorcellesressudens.eerv.ch/
+region: La Broye
+---

--- a/content/vd/pays-d-enhaut.md
+++ b/content/vd/pays-d-enhaut.md
@@ -1,0 +1,22 @@
+---
+title: Paroisse du Pays d'Enhaut
+name: Pays-d'Enhaut
+site: https://paysdenhaut.eerv.ch
+territoire:
+    - Château-d'Oex
+    - Rossinière
+    - Rougemont
+NPA:
+    - 1658
+    - 1659
+    - 1660
+meta:
+    - Flendruz
+    - L'Etivaz
+    - La Chaudanne
+    - La Lécherette
+    - La Tine
+    - Les Granges
+    - Les Moulins
+region: Riviera - Pays-d'Enhaut
+---

--- a/content/vd/penthalaz.md
+++ b/content/vd/penthalaz.md
@@ -1,0 +1,16 @@
+---
+title: Paroisse de Penthalaz - Penthaz - Daillens
+name: Penthalaz
+site: https://penthalaz.eerv.ch
+territoire:
+    - Daillens
+    - Penthalaz
+    - Penthaz
+NPA:
+    - 1303
+    - 1305
+    - 1306
+meta:
+    - Cossonay-Gare
+region: Gros-de-Vaud - Venoge
+---

--- a/content/vd/pied-du-jura.md
+++ b/content/vd/pied-du-jura.md
@@ -1,0 +1,32 @@
+---
+title: Paroisse du Pied du Jura
+name: Pied du Jura
+site: https://pieddujura.eerv.ch
+territoire:
+    - Apples
+    - Ballens
+    - Berolle
+    - Bière
+    - Bussy-Chardonney
+    - Cottens VD
+    - Mollens VD
+    - Pampigny
+    - Reverolle
+    - Sévery
+NPA:
+    - 1116
+    - 1128
+    - 1136
+    - 1141
+    - 1142
+    - 1143
+    - 1144
+    - 1145
+    - 1146
+    - 1149
+meta:
+    - Bussy-sur-Morges
+    - Chardonney-sur-Morges
+    - Hameau de Froideville
+region: Morges - Aubonne
+---

--- a/content/vd/plateau-du-jorat.md
+++ b/content/vd/plateau-du-jorat.md
@@ -1,0 +1,35 @@
+---
+title: Paroisse du Plateau du Jorat
+name: Plateau du Jorat
+site: https://plateaudujorat.eerv.ch
+territoire:
+    - Boulens
+    - Jorat-Menthue
+    - Montanaire
+    - Ogens
+    - Villars-le-Comte
+NPA:
+    - 1045
+    - 1059
+    - 1061
+    - 1062
+    - 1063
+    - 1410
+    - 1515
+meta:
+    - Chanéaz
+    - Chapelle-sur-Moudon
+    - Correvon
+    - Denezy
+    - Martherenges
+    - Montaubion-Chardonney
+    - Neyruz-sur-Moudon
+    - Peney-le-Jorat
+    - Peyres-Possens
+    - Saint-Cierges
+    - Sottens
+    - Thierrens
+    - Villars-Mendraz
+    - Villars-Tiercelin
+region: Gros-de-Vaud - Venoge
+---

--- a/content/vd/pomy-gressy-suchy.md
+++ b/content/vd/pomy-gressy-suchy.md
@@ -1,0 +1,31 @@
+---
+title: Paroisse de Pomy - Gressy - Suchy
+name: Pomy - Gressy - Suchy
+site: https://pomygressysuchy.eerv.ch
+territoire:
+    - Belmont-sur-Yverdon
+    - Cronay
+    - Cuarny
+    - Ependes VD
+    - Pomy
+    - Suchy
+    - Ursins
+    - Valeyres-sous-Ursins
+    - Villars-Epeney
+    - Yverdon-les-Bains
+NPA:
+    - 1404
+    - 1405
+    - 1406
+    - 1412
+    - 1432
+    - 1433
+    - 1434
+meta:
+    - Calamin
+    - Chevressy
+    - Gressy
+    - Le Villaret
+    - Yverdon-les-Bains
+region: Nord vaudois
+---

--- a/content/vd/prilly-jouxtens.md
+++ b/content/vd/prilly-jouxtens.md
@@ -1,0 +1,11 @@
+---
+title: Paroisse de Prilly - Jouxtens
+name: Prilly - Jouxtens
+site: https://prillyjouxtens.eerv.ch
+territoire:
+    - Jouxtens-Mézery
+    - Prilly
+NPA:
+    - 1008
+region: Les Chamberonnes
+---

--- a/content/vd/pully-paudex.md
+++ b/content/vd/pully-paudex.md
@@ -1,0 +1,15 @@
+---
+title: Paroisse de Pully - Paudex
+name: Pully - Paudex
+site: https://pullypaudex.eerv.ch
+territoire:
+    - Paudex
+    - Pully
+NPA:
+    - 1009
+    - 1094
+meta:
+    - Les Monts-de-Pully
+    - Trois Chasseurs
+region: Lavaux
+---

--- a/content/vd/renens.md
+++ b/content/vd/renens.md
@@ -1,0 +1,10 @@
+---
+title: Paroisse de Renens
+name: Renens
+site: https://renens.eerv.ch
+territoire:
+    - Renens VD
+NPA:
+    - 1020
+region: Les Chamberonnes
+---

--- a/content/vd/saint-cergue.md
+++ b/content/vd/saint-cergue.md
@@ -1,0 +1,14 @@
+---
+title: Paroisse de Saint-Cergue
+name: Saint-Cergue
+site: https://saintcergue.eerv.ch
+territoire:
+    - Arzier-Le Muids
+    - Saint-Cergue
+NPA:
+    - 1264
+    - 1273
+meta:
+    - La Cure
+region: La Côte
+---

--- a/content/vd/saint-francois-saint-jacques.md
+++ b/content/vd/saint-francois-saint-jacques.md
@@ -1,0 +1,28 @@
+---
+title: Paroisse de Saint-François - Saint-Jacques
+name: Saint-François - Saint-Jacques
+site: https://saintfrancoissaintjacques.eerv.ch
+territoire:
+    - Lausanne
+    - Pully
+NPA:
+    - 1000
+    - 1003
+    - 1005
+    - 1006
+    - 1007
+    - 1009
+meta:
+    - Lausanne 25
+    - Lausanne 26
+    - Lausanne 27
+    - Le Chalet-à-Gobet
+    - Les Monts-de-Pully
+    - Montblesson
+    - Montheron
+    - Trois Chasseurs
+    - Vernand-Dessous
+    - Vernand-Dessus
+    - Vers-chez-les-Blanc
+region: Lausanne - Epalinges
+---

--- a/content/vd/saint-jean.md
+++ b/content/vd/saint-jean.md
@@ -1,0 +1,18 @@
+---
+title: Paroisse de Saint-Jean
+name: Saint-Jean
+site: https://saintjean.eerv.ch
+territoire:
+    - Lausanne
+NPA:
+    - 1006
+    - 1007
+meta:
+    - Le Chalet-à-Gobet
+    - Montblesson
+    - Montheron
+    - Vernand-Dessous
+    - Vernand-Dessus
+    - Vers-chez-les-Blanc
+region: Lausanne - Epalinges
+---

--- a/content/vd/saint-laurent-eglise.md
+++ b/content/vd/saint-laurent-eglise.md
@@ -1,0 +1,6 @@
+---
+title: 
+name: Saint-Laurent-Eglise
+site: https://saintlaurenteglise.eerv.ch
+region: 
+---

--- a/content/vd/saint-laurent-les-bergieres.md
+++ b/content/vd/saint-laurent-les-bergieres.md
@@ -1,0 +1,22 @@
+---
+title: Paroisse de Saint-Laurent - Les Bergières
+name: Saint-laurent - Les Bergières
+site: https://saintlaurentlesbergieres.eerv.ch
+territoire:
+    - Jouxtens-Mézery
+    - Lausanne
+    - Prilly
+NPA:
+    - 1003
+    - 1004
+    - 1005
+    - 1008
+meta:
+    - Le Chalet-à-Gobet
+    - Montblesson
+    - Montheron
+    - Vernand-Dessous
+    - Vernand-Dessus
+    - Vers-chez-les-Blanc
+region: Lausanne - Epalinges
+---

--- a/content/vd/saint-prex-lussy-vufflens.md
+++ b/content/vd/saint-prex-lussy-vufflens.md
@@ -1,0 +1,29 @@
+---
+title: Paroisse de Saint-Prex - Lussy - Vufflens
+name: Saint-Prex - Lussy - Vufflens
+site: https://saintprexlussyvufflens.eerv.ch
+territoire:
+    - Chigny
+    - Denens
+    - Lully VD
+    - Lussy-sur-Morges
+    - Saint-Prex
+    - Tolochenaz
+    - Vaux-sur-Morges
+    - Villars-sous-Yens
+    - Vufflens-le-Château
+    - Yens
+NPA:
+    - 1126
+    - 1131
+    - 1132
+    - 1134
+    - 1135
+    - 1162
+    - 1167
+    - 1168
+    - 1169
+meta:
+    - Lussy
+region: Morges - Aubonne
+---

--- a/content/vd/saint-saphorin.md
+++ b/content/vd/saint-saphorin.md
@@ -1,0 +1,31 @@
+---
+title: Paroisse de Saint-Saphorin
+name: Saint-Saphorin
+site: https://saintsaphorin.eerv.ch
+territoire:
+    - Bourg-en-Lavaux
+    - Chardonne
+    - Chexbres
+    - Puidoux
+    - Rivaz
+    - Saint-Saphorin (Lavaux)
+NPA:
+    - 1070
+    - 1071
+    - 1098
+    - 1803
+meta:
+    - Cremières
+    - Cully
+    - Epesses
+    - Grandvaux
+    - Grangeneuve
+    - La Croix
+    - Le Mont-Pèlerin
+    - Lignières
+    - Publoz
+    - Riex
+    - Treytorrens  (Lavaux)
+    - Villette
+region: Lavaux
+---

--- a/content/vd/sauteruz.md
+++ b/content/vd/sauteruz.md
@@ -1,0 +1,25 @@
+---
+title: Paroisse du Sauteruz
+name: Sauteruz
+site: https://sauteruz.eerv.ch
+territoire:
+    - Bercher
+    - Essertines-sur-Yverdon
+    - Fey
+    - Orzens
+    - Pailly
+    - Vuarrens
+NPA:
+    - 1038
+    - 1044
+    - 1413
+    - 1416
+    - 1417
+    - 1418
+meta:
+    - Epautheyres
+    - La Robellaz
+    - Nonfoux
+    - Vuarrengel
+region: Gros-de-Vaud - Venoge
+---

--- a/content/vd/savigny-forel.md
+++ b/content/vd/savigny-forel.md
@@ -1,0 +1,15 @@
+---
+title: Paroisse de Savigny - Forel
+name: Savigny - Forel
+site: https://savignyforel.eerv.ch
+territoire:
+    - Forel (Lavaux)
+    - Savigny
+NPA:
+    - 1072
+    - 1073
+meta:
+    - La Claie-aux-Moines
+    - Mollie-Margot
+region: Lavaux
+---

--- a/content/vd/sud-ouest-lausannois.md
+++ b/content/vd/sud-ouest-lausannois.md
@@ -1,0 +1,28 @@
+---
+title: Paroisse du Sud-Ouest lausannois
+name: Sud-Ouest lausannois
+site: https://sudouestlausannois.eerv.ch
+territoire:
+    - Jouxtens-Mézery
+    - Lausanne
+    - Prilly
+    - Pully
+    - Renens VD
+NPA:
+    - 1003
+    - 1004
+    - 1007
+    - 1008
+    - 1009
+    - 1020
+meta:
+    - Le Chalet-à-Gobet
+    - Les Monts-de-Pully
+    - Montblesson
+    - Montheron
+    - Trois Chasseurs
+    - Vernand-Dessous
+    - Vernand-Dessus
+    - Vers-chez-les-Blanc
+region: Lausanne - Epalinges
+---

--- a/content/vd/talent.md
+++ b/content/vd/talent.md
@@ -1,0 +1,46 @@
+---
+title: Paroisse du Talent
+name: Talent
+site: https://talent.eerv.ch
+territoire:
+    - Assens
+    - Bettens
+    - Bioley-Orjulaz
+    - Bottens
+    - Echallens
+    - Etagnières
+    - Goumoëns
+    - Jorat-Menthue
+    - Montilliez
+    - Oulens-sous-Echallens
+    - Penthéréaz
+    - Poliez-Pittet
+    - Saint-Barthélemy VD
+    - Villars-le-Terroir
+NPA:
+    - 1037
+    - 1040
+    - 1041
+    - 1042
+    - 1375
+    - 1376
+    - 1377
+meta:
+    - Assens
+    - Dommartin
+    - Eclagnens
+    - Goumoens-la-Ville
+    - Goumoens-le-Jux
+    - Goumoëns-la-Ville
+    - Goumoëns-le-Jux
+    - Malapalud
+    - Montaubion-Chardonney
+    - Naz
+    - Peney-le-Jorat
+    - Poliez-le-Grand
+    - Sottens
+    - Sugnens
+    - Villars-Mendraz
+    - Villars-Tiercelin
+region: Gros-de-Vaud - Venoge
+---

--- a/content/vd/terre-sainte-celigny.md
+++ b/content/vd/terre-sainte-celigny.md
@@ -1,0 +1,25 @@
+---
+title: Paroisse de Terre Sainte - Céligny
+name: Terre Sainte - Céligny
+site: https://terresainte.eerv.ch
+territoire:
+    - Bogis-Bossey
+    - Chavannes-de-Bogis
+    - Chavannes-des-Bois
+    - Commugny
+    - Coppet
+    - Founex
+    - Mies
+    - Tannay
+NPA:
+    - 1279
+    - 1290
+    - 1291
+    - 1295
+    - 1296
+    - 1297
+meta:
+    - Bossey
+    - Chataigneriaz
+region: La Côte
+---

--- a/content/vd/vallorbe.md
+++ b/content/vd/vallorbe.md
@@ -1,0 +1,13 @@
+---
+title: Paroisse de Vallorbe
+name: Vallorbe
+site: https://vallorbe.eerv.ch
+territoire:
+    - Vallorbe
+NPA:
+    - 1337
+meta:
+    - Le Creux
+    - Le Day
+region: Joux - Orbe
+---

--- a/content/vd/vaulion-romainmotier.md
+++ b/content/vd/vaulion-romainmotier.md
@@ -1,0 +1,38 @@
+---
+title: Paroisse de Vaulion - Romainmôtier
+name: Vaulion - Romainmôtier
+site: https://vaulionromainmotier.eerv.ch
+territoire:
+    - Bretonnières
+    - Chavannes-le-Veyron
+    - Croy
+    - Cuarnens
+    - Juriens
+    - L'Isle
+    - La Praz
+    - Mauraz
+    - Moiry
+    - Mont-la-Ville
+    - Premier
+    - Romainmôtier-Envy
+    - Vaulion
+NPA:
+    - 1148
+    - 1322
+    - 1323
+    - 1324
+    - 1325
+    - 1326
+    - 1329
+meta:
+    - Envy
+    - La Coudre
+    - Le Cosson
+    - Les Mousses
+    - Moiry VD
+    - Mollendruz
+    - Romainmôtier
+    - Saint-Denis
+    - Villars-Bozon
+region: Joux - Orbe
+---

--- a/content/vd/vevey.md
+++ b/content/vd/vevey.md
@@ -1,0 +1,10 @@
+---
+title: Paroisse de Vevey
+name: Vevey
+site: https://vevey.eerv.ch
+territoire:
+    - Vevey
+NPA:
+    - 1800
+region: Riviera - Pays-d'Enhaut
+---

--- a/content/vd/veyron-venoge.md
+++ b/content/vd/veyron-venoge.md
@@ -1,0 +1,25 @@
+---
+title: Paroisse de Veyron - Venoge
+name: Veyron - Venoge
+site: https://veyronvenoge.eerv.ch
+territoire:
+    - Chavannes-le-Veyron
+    - Cuarnens
+    - L'Isle
+    - La Praz
+    - Mauraz
+    - Moiry
+    - Mont-la-Ville
+    - Montricher
+NPA:
+    - 1147
+    - 1148
+meta:
+    - La Coudre
+    - Les Mousses
+    - Moiry VD
+    - Mollendruz
+    - Saint-Denis
+    - Villars-Bozon
+region: Gros-de-Vaud - Venoge
+---

--- a/content/vd/villeneuve-noville.md
+++ b/content/vd/villeneuve-noville.md
@@ -1,0 +1,20 @@
+---
+title: Paroisse de Villeneuve – Haut-Lac
+name: Villeneuve - Noville
+site: https://villeneuvehautlac.eerv.ch
+territoire:
+    - Chessel
+    - Noville
+    - Rennaz
+    - Roche VD
+    - Villeneuve VD
+NPA:
+    - 1844
+    - 1845
+    - 1846
+    - 1847
+    - 1852
+meta:
+    - Crebelley
+region: Chablais vaudois
+---

--- a/content/vd/villette.md
+++ b/content/vd/villette.md
@@ -1,0 +1,22 @@
+---
+title: Paroisse de Villette
+name: Villette
+site: https://villette.eerv.ch
+territoire:
+    - Bourg-en-Lavaux
+NPA:
+    - 1091
+    - 1096
+    - 1097
+    - 1098
+meta:
+    - Aran
+    - Chenaux
+    - Cully
+    - Epesses
+    - Grandvaux
+    - Riex
+    - Villette
+    - Villette (Lavaux)
+region: Lavaux
+---

--- a/content/vd/vufflens-la-ville.md
+++ b/content/vd/vufflens-la-ville.md
@@ -1,0 +1,18 @@
+---
+title: Paroisse de Vufflens-la-Ville
+name: Vufflens-la-Ville
+site: https://vufflenslaville.eerv.ch
+territoire:
+    - Bournens
+    - Boussens
+    - Mex VD
+    - Sullens
+    - Vufflens-la-Ville
+NPA:
+    - 1031
+    - 1034
+    - 1035
+    - 1036
+    - 1302
+region: Gros-de-Vaud - Venoge
+---

--- a/content/vd/vully-avenches.md
+++ b/content/vd/vully-avenches.md
@@ -1,0 +1,40 @@
+---
+title: Paroisse de Vully - Avenches
+name: Vully - Avenches
+site: https://vullyavenches.eerv.ch
+territoire:
+    - Avenches
+    - Cudrefin
+    - Faoug
+    - Vully-les-Lacs
+NPA:
+    - 1580
+    - 1584
+    - 1585
+    - 1586
+    - 1587
+    - 1588
+    - 1589
+    - 1595
+    - 1787
+meta:
+    - Avenches
+    - Bellerive
+    - Bellerive VD
+    - Chabrey
+    - Champmartin
+    - Constantine
+    - Cotterd
+    - Donatyre
+    - Haras national
+    - La Sauge
+    - Montet  (Vully)
+    - Montmagny
+    - Mur
+    - Mur (Vully) VD
+    - Oleyres
+    - Salavaux
+    - Vallamand
+    - Villars-le-Grand
+region: La Broye
+---

--- a/content/vd/yverdon-fontenay-les-cygnes.md
+++ b/content/vd/yverdon-fontenay-les-cygnes.md
@@ -1,0 +1,14 @@
+---
+title: Paroisse d'Yverdon-Fontenay - Les Cygnes
+name: Yverdon-Fontenay - Les Cygnes
+site: https://yverdonfontenaylescygnes.eerv.ch
+territoire:
+    - Cheseaux-Noréaz
+    - Yverdon-les-Bains
+NPA:
+    - 1400
+meta:
+    - Gressy
+    - Yverdon-les-Bains
+region: Nord vaudois
+---

--- a/content/vd/yverdon-temple.md
+++ b/content/vd/yverdon-temple.md
@@ -1,0 +1,14 @@
+---
+title: Paroisse d'Yverdon-Temple
+name: Yverdon-Temple
+site: https://yverdontemple.eerv.ch
+territoire:
+    - Cheseaux-Noréaz
+    - Yverdon-les-Bains
+NPA:
+    - 1400
+meta:
+    - Gressy
+    - Yverdon-les-Bains
+region: Nord vaudois
+---

--- a/content/vd/yvonand.md
+++ b/content/vd/yvonand.md
@@ -1,0 +1,22 @@
+---
+title: Paroisse d'Yvonand
+name: Yvonand
+site: https://yvonand.eerv.ch
+territoire:
+    - Cuarny
+    - Rovray
+    - Villars-Epeney
+    - Yvonand
+NPA:
+    - 1404
+    - 1462
+    - 1463
+meta:
+    - Arrissoules
+    - La Grand-Moille
+    - La Mauguettaz
+    - Le Moulin
+    - Niédens
+    - Rovray
+region: Nord vaudois
+---


### PR DESCRIPTION
Ajout des paroisses vaudoises, à partir d'informations srappées depuis:

- eerv.ch (la fonction de recherche par NPA)
- https://www.ucv.ch/annuaire/recherche-par-localite (pour faire correspondre communes et localités, ou `territoire` et `meta`)
- https://www.cadastre.ch/content/cadastre-internet/fr/services/service/registry/plz/_jcr_content/contentPar/tabs/items/dokumente/tabPar/downloadlist/downloadItems/517_1469711943806.download/Ortschaftenverzeichnis-Produktinfo-fr.pdf

## Erreurs connues

Je sais que le set contient des erreurs, notamment, la principale étant que les NPA suivants `1342, 1808, 1122, 1833, 1046, 1015, 1127, 1093, 1824, 1115, 1832, 1884, 1809, 1047, 1114, 1265, 1113, 1823, 1123, 1885, 1068` renvoient une erreur depuis le site eerv.ch:

- soit renvoie vers www.eerv.ch au lieu d'une paroisse  (p.ex. `1114`)
- soit retourne le message `Pas de paroisse pour le code postal:` (p.ex. `1068`)

Il faudrait les rajouter à la main, une foi que le set est validé.

## Options

### Multiparoisses

Certaines localités couvrent plusieurs paroisses (notamment à Lausanne, p.ex. `1006`). Le site de l'eerv.ch renvoie une liste de rue pour savoir précisément quel rue est sur quelle paroisse. Dans ces cas, j'ai pris l'option de rajouter le NPA en question à toutes les paroisses potentiellement couvertes. Ainsi p.ex. `1006` va renvoyer vers les 2 paroisses potentielles (Paroisse de Saint-François - Saint-Jacques (Vaud), et Paroisse de Saint-Jean (Vaud)) sans qu'il y ait moyen d'aller plus en détail.

### Nomenclatures

Pour repérer les doublons, j'ai pris l'option de remplacer "St[e]-" par "Saint[e]", et " (VD)" par " VD" (pour garder le VD quand il y a une localité sur plusieurs cantons).

### Eglise exclusive

J'ai pris l'option d'exclure les lieux phares, aumôneries et paroisses de langues allemandes pour l'instant.
À voir comment ma-paroisse.ch veut inclure ce genre de choses.